### PR TITLE
Added type support for structured output in the R1 research agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.11
+
+Added type support for structured output in the R1 research agent.
+
 ## 0.1.10
 
 Small bug fix in the /me endpoint. It used to throw an error, but that was unwanted behavior. Now it returns either a `success` or `error` status, depending on the validity of the API key.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utopianlabs",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Official TypeScript SDK for the Utopian Labs API",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -163,6 +163,7 @@ export const zPostAgentRunBaseRequest = z.object({
     }, "This callback URL is not allowed")
     .optional(),
   use_memory: z.boolean().optional(), // if true, the agent will remember what it found in previous research runs
+  output_schema: z.record(z.string(), z.unknown()).optional(), // if provided, the agent will return a structured output in the requested JSON format
 });
 
 export const zPostResearchAgentRunRequest = zPostAgentRunBaseRequest.extend({
@@ -285,6 +286,7 @@ const zGetResearchRunWithResultResponse = zResponse.extend({
       .object({
         steps: z.array(zResearchStep),
         conclusion: z.string().optional(),
+        output: z.record(z.string(), z.unknown()).optional(),
       })
       .nullish(),
   }),


### PR DESCRIPTION
We recently added 'structured outputs' as a feature to the R1 research agents. This also adds the necessary types to the TypeScript SDK.