### PR TITLE
Added `x_handle` to lead type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.12
+
+Added support for the new `x_handle` param in the lead person type, allowing the agent to search someone's X posts.
+
 ## 0.1.11
 
 Added type support for structured output in the R1 research agent.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "utopianlabs",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Official TypeScript SDK for the Utopian Labs API",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -86,6 +86,10 @@ const zPerson = z.object({
     .max(500, "linkedin url must be less than 500 characters")
     .refine(isValidDomainOrUrl, "Please enter a valid URL or domain")
     .optional(),
+  x_handle: z
+    .string()
+    .max(100, "x handle must be less than 100 characters")
+    .optional(),
   email: z
     .string()
     .email()


### PR DESCRIPTION
Added the new param `x_handle` to the person type.

If passed in, the agent can use the `x_handle` to search through the lead's X posts.